### PR TITLE
[FIX]  Dropdown menu don't show as expected

### DIFF
--- a/app/soapbox/utils/features.ts
+++ b/app/soapbox/utils/features.ts
@@ -506,6 +506,7 @@ const getInstanceFeatures = (instance: Instance) => {
      */
     quotePosts: any([
       (v.software === PLEROMA || v.software === AKKOMA) && v.build === SOAPBOX && gte(v.version, '2.4.50'),
+      features.includes('quote_posting'),
       instance.feature_quote === true,
     ]),
 


### PR DESCRIPTION
When click the quote button in status action bar, the dropdown menu don't show as expected

<img width="214" alt="image" src="https://user-images.githubusercontent.com/91365763/226359160-44533f87-c971-4575-bc81-18e09b96d7b8.png"> 