### PR TITLE
[FIX] editing post with the original content_type

### DIFF
--- a/app/soapbox/actions/statuses.ts
+++ b/app/soapbox/actions/statuses.ts
@@ -122,7 +122,7 @@ const editStatus = (id: string) => (dispatch: AppDispatch, getState: () => RootS
 
   api(getState).get(`/api/v1/statuses/${id}/source`).then(response => {
     dispatch({ type: STATUS_FETCH_SOURCE_SUCCESS });
-    dispatch(setComposeToStatus(status, response.data.text, response.data.spoiler_text, false));
+    dispatch(setComposeToStatus(status, response.data.text, response.data.spoiler_text, response.data.content_type));
     dispatch(openModal('COMPOSE'));
   }).catch(error => {
     dispatch({ type: STATUS_FETCH_SOURCE_FAIL, error });


### PR DESCRIPTION
**Before:** 
Regardless of the status’ content_type, editing it as plain text.

**After**: 
Keeping the original content_type, editing the status as is.