### PR TITLE
[FIX] Content type inconsistency when replying without refresh

### DIFF
--- a/app/soapbox/reducers/compose.ts
+++ b/app/soapbox/reducers/compose.ts
@@ -143,6 +143,7 @@ export const statusToMentionsAccountIdsArray = (status: StatusEntity, account: A
 function clearAll(state: State) {
   return ReducerRecord({
     content_type: state.default_content_type,
+    default_content_type: state.default_content_type,
     privacy: state.default_privacy,
     idempotencyKey: uuid(),
   });


### PR DESCRIPTION
Without refreshing the page, when a user posts the first reply to a status, the content type is correct according to the default setting. However, when the user tries to reply to another status within the same page, the default content type is changed unexpectedly. 

<img width="651" alt="image" src="https://github.com/BDX-town/Mangane/assets/91365763/d7c4137b-5de6-4a9e-9171-5ea5d69612aa">
<img width="651" alt="image" src="https://github.com/BDX-town/Mangane/assets/91365763/9b0442b4-8a0c-404d-bdff-783f162ae1a9">
