### PR TITLE
[FIX] atoms on tag

### DIFF
--- a/app/soapbox/components/announcements/announcement-content.tsx
+++ b/app/soapbox/components/announcements/announcement-content.tsx
@@ -30,7 +30,7 @@ const AnnouncementContent: React.FC<IAnnouncementContent> = ({ announcement }) =
     if (e.button === 0 && !(e.ctrlKey || e.metaKey)) {
       e.preventDefault();
       e.stopPropagation();
-      history.push(`/tags/${hashtag}`);
+      history.push(`/tag/${hashtag}`);
     }
   };
 

--- a/app/soapbox/components/hashtag.tsx
+++ b/app/soapbox/components/hashtag.tsx
@@ -23,7 +23,7 @@ const Hashtag: React.FC<IHashtag> = ({ hashtag }) => {
   return (
     <HStack alignItems='center' justifyContent='between' data-testid='hashtag'>
       <Stack>
-        <Permalink href={hashtag.url} to={`/tags/${hashtag.name}`} className='hover:underline'>
+        <Permalink href={hashtag.url} to={`/tag/${hashtag.name}`} className='hover:underline'>
           <Text tag='span' size='sm' weight='semibold'>#{hashtag.name}</Text>
         </Permalink>
 

--- a/app/soapbox/components/status_content.tsx
+++ b/app/soapbox/components/status_content.tsx
@@ -99,7 +99,7 @@ const StatusContent: React.FC<IStatusContent> = ({ status, expanded = false, onE
     if (e.button === 0 && !(e.ctrlKey || e.metaKey)) {
       e.preventDefault();
       e.stopPropagation();
-      history.push(`/tags/${hashtag}`);
+      history.push(`/tag/${hashtag}`);
     }
   };
 

--- a/app/soapbox/features/ui/index.tsx
+++ b/app/soapbox/features/ui/index.tsx
@@ -207,7 +207,7 @@ const SwitchingColumnsArea: React.FC = ({ children }) => {
       <Redirect from='/main/all' to='/timeline/fediverse' />
       <Redirect from='/main/public' to='/timeline/local' />
       <Redirect from='/main/friends' to='/' />
-      <Redirect from='/tag/:id' to='/tags/:id' />
+      <Redirect from='/tags/:id' to='/tag/:id' />
       <Redirect from='/user-settings' to='/settings/profile' />
       <WrappedRoute path='/notice/:statusId' publicRoute exact page={DefaultPage} component={Status} content={children} />
       <Redirect from='/users/:username/statuses/:statusId' to='/@:username/posts/:statusId' />
@@ -243,7 +243,7 @@ const SwitchingColumnsArea: React.FC = ({ children }) => {
       <Redirect from='/auth/password/new' to='/reset-password' />
       <Redirect from='/auth/password/edit' to={`/edit-password${search}`} />
 
-      <WrappedRoute path='/tags/:id' publicRoute page={DefaultPage} component={HashtagTimeline} content={children} />
+      <WrappedRoute path='/tag/:id' publicRoute page={DefaultPage} component={HashtagTimeline} content={children} />
 
       {features.lists && <WrappedRoute path='/lists' page={DefaultPage} component={Lists} content={children} />}
       {features.lists && <WrappedRoute path='/list/:id' page={HomePage} component={ListTimeline} content={children} />}


### PR DESCRIPTION
The `/tags/:id` route seems to be used by Akkoma to generate .atom files.

Because of that, someone accessing this route with having Mangane in their cache will be prompted to download an atom file instead of seeing the tag UI. 

fix https://github.com/BDX-town/Mangane/issues/193