### PR TITLE
[Fix] Timeline jump

### DIFF
--- a/app/soapbox/actions/timelines.ts
+++ b/app/soapbox/actions/timelines.ts
@@ -245,6 +245,7 @@ const expandTimelineSuccess = (timeline: string, statuses: APIEntity[], next: st
   partial,
   isLoadingRecent,
   skipLoading: !isLoadingMore,
+  isLoadingMore,
 });
 
 const expandTimelineFail = (timeline: string, error: AxiosError, isLoadingMore: boolean) => ({

--- a/app/soapbox/components/scroll-top-button.tsx
+++ b/app/soapbox/components/scroll-top-button.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import throttle from 'lodash/throttle';
 import React, { useState, useEffect, useCallback } from 'react';
 import { useIntl, MessageDescriptor } from 'react-intl';
@@ -34,35 +33,27 @@ const ScrollTopButton: React.FC<IScrollTopButton> = ({
   const [scrolled, setScrolled] = useState<boolean>(false);
   const autoload = settings.get('autoloadTimelines') === true;
 
-  const visible = count > 0 && scrolled;
-
-  const classes = classNames('left-1/2 -translate-x-1/2 fixed top-20 z-50', {
-    'hidden': !visible,
-  });
-
-  const getScrollTop = (): number => {
+  const getScrollTop = React.useCallback((): number => {
     return (document.scrollingElement || document.documentElement).scrollTop;
-  };
+  }, []);
 
-  const maybeUnload = () => {
+  const maybeUnload = React.useCallback(() => {
     if (autoload && getScrollTop() <= autoloadThreshold) {
       onClick();
     }
-  };
+  }, [autoload, autoloadThreshold, onClick]);
 
   const handleScroll = useCallback(throttle(() => {
-    maybeUnload();
-
     if (getScrollTop() > threshold) {
       setScrolled(true);
     } else {
       setScrolled(false);
     }
-  }, 150, { trailing: true }), [autoload, threshold, autoloadThreshold, onClick]);
+  }, 150, { trailing: true }), [threshold]);
 
-  const scrollUp = () => {
+  const scrollUp = React.useCallback(() => {
     window.scrollTo({ top: 0 });
-  };
+  }, []);
 
   const handleClick: React.MouseEventHandler = () => {
     setTimeout(scrollUp, 10);
@@ -81,17 +72,21 @@ const ScrollTopButton: React.FC<IScrollTopButton> = ({
     maybeUnload();
   }, [count]);
 
-  return (
-    <div className={classes}>
-      <a className='flex items-center bg-primary-600 hover:bg-primary-700 hover:scale-105 active:scale-100 transition-transform text-white rounded-full px-4 py-2 space-x-1.5 cursor-pointer whitespace-nowrap' onClick={handleClick}>
-        <Icon src={require('@tabler/icons/arrow-bar-to-up.svg')} />
+  const visible = React.useMemo(() => count > 0 && scrolled, [count, scrolled]) ;
 
-        {(count > 0) && (
-          <Text theme='inherit' size='sm'>
-            {intl.formatMessage(message, { count })}
-          </Text>
-        )}
-      </a>
+  if (!visible) return null;
+
+  return (
+    <div className='left-1/2 -translate-x-1/2 fixed top-20 z-50'>
+      <button
+        className='flex items-center bg-primary-600 hover:bg-primary-700 hover:scale-105 active:scale-100 transition-transform text-white rounded-full px-4 py-2 space-x-1.5 cursor-pointer whitespace-nowrap' 
+        onClick={handleClick}
+      >
+        <Icon src={require('@tabler/icons/arrow-bar-to-up.svg')} />
+        <Text theme='inherit' size='sm'>
+          {intl.formatMessage(message, { count })}
+        </Text>
+      </button>
     </div>
   );
 };

--- a/app/soapbox/features/ui/components/timeline.tsx
+++ b/app/soapbox/features/ui/components/timeline.tsx
@@ -1,6 +1,7 @@
 import { OrderedSet as ImmutableOrderedSet } from 'immutable';
 import debounce from 'lodash/debounce';
 import React, { useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { defineMessages } from 'react-intl';
 
 import { dequeueTimeline, scrollTopTimeline } from 'soapbox/actions/timelines';
@@ -53,13 +54,14 @@ const Timeline: React.FC<ITimeline> = ({
 
   return (
     <>
-      <ScrollTopButton
-        key='timeline-queue-button-header'
-        onClick={handleDequeueTimeline}
-        count={totalQueuedItemsCount}
-        message={messages.queue}
-      />
-
+      {
+        createPortal(<ScrollTopButton
+          key='timeline-queue-button-header'
+          onClick={handleDequeueTimeline}
+          count={totalQueuedItemsCount}
+          message={messages.queue}
+        />, document.body)
+      }
       <StatusList
         timelineId={timelineId}
         onScrollToTop={handleScrollToTop}

--- a/app/soapbox/reducers/timelines.ts
+++ b/app/soapbox/reducers/timelines.ts
@@ -111,7 +111,10 @@ const expandNormalizedTimeline = (state: State, timelineId: string, statuses: Im
         // we need to sort between queue and actual list to avoid
         // messing with user position in the timeline by inserting inseen statuses
         unseens = ImmutableOrderedSet<any>();
-        if (!isLoadingMore && timeline.items.count() > 0) {
+        if (!isLoadingMore
+          && timeline.items.count() > 0
+          && newIds.first() > timeline.items.first()
+        ) {
           unseens = newIds.subtract(timeline.items);
         }
 

--- a/app/soapbox/reducers/timelines.ts
+++ b/app/soapbox/reducers/timelines.ts
@@ -89,32 +89,43 @@ const setFailed = (state: State, timelineId: string, failed: boolean) => {
   return state.update(timelineId, TimelineRecord(), timeline => timeline.set('loadingFailed', failed));
 };
 
-const expandNormalizedTimeline = (state: State, timelineId: string, statuses: ImmutableList<ImmutableMap<string, any>>, next: string | null, isPartial: boolean, isLoadingRecent: boolean) => {
-  const newIds = getStatusIds(statuses);
+const expandNormalizedTimeline = (state: State, timelineId: string, statuses: ImmutableList<ImmutableMap<string, any>>, next: string | null, isPartial: boolean, isLoadingRecent: boolean, isLoadingMore: boolean) => {
+  let newIds = getStatusIds(statuses);
+  let unseens = ImmutableOrderedSet<any>();
 
-  return state.update(timelineId, TimelineRecord(), timeline => timeline.withMutations(timeline => {
-    timeline.set('isLoading', false);
-    timeline.set('loadingFailed', false);
-    timeline.set('isPartial', isPartial);
-
-    if (!next && !isLoadingRecent) timeline.set('hasMore', false);
-
-    // Pinned timelines can be replaced entirely
-    if (timelineId.endsWith(':pinned')) {
-      timeline.set('items', newIds);
-      return;
-    }
-
-    if (!newIds.isEmpty()) {
-      timeline.update('items', oldIds => {
-        if (newIds.first() > oldIds.first()!) {
-          return mergeStatusIds(oldIds, newIds);
-        } else {
-          return mergeStatusIds(newIds, oldIds);
+  return state.withMutations((s) => {
+    s.update(timelineId, TimelineRecord(), timeline => timeline.withMutations(timeline => {
+      timeline.set('isLoading', false);
+      timeline.set('loadingFailed', false);
+      timeline.set('isPartial', isPartial);
+  
+      if (!next && !isLoadingRecent) timeline.set('hasMore', false);
+  
+      // Pinned timelines can be replaced entirely
+      if (timelineId.endsWith(':pinned')) {
+        timeline.set('items', newIds);
+        return;
+      }
+  
+      if (!newIds.isEmpty()) {
+        // we need to sort between queue and actual list to avoid
+        // messing with user position in the timeline by inserting inseen statuses
+        let unseens = ImmutableOrderedSet<any>();
+        if (!isLoadingMore && timeline.items.count() > 0) {
+          unseens = newIds.subtract(timeline.items);
         }
-      });
-    }
-  }));
+        newIds = newIds.subtract(unseens);
+        timeline.update('items', oldIds => {
+          if (newIds.first() > oldIds.first()!) {
+            return mergeStatusIds(oldIds, newIds);
+          } else {
+            return mergeStatusIds(newIds, oldIds);
+          }
+        });
+      }
+    }));
+    unseens.forEach((statusId) => updateTimelineQueue(s, timelineId, statusId));
+  });
 };
 
 const updateTimeline = (state: State, timelineId: string, statusId: string) => {
@@ -149,6 +160,7 @@ const updateTimelineQueue = (state: State, timelineId: string, statusId: string)
     timeline.set('totalQueuedItemsCount', queuedCount + 1);
     timeline.set('queuedItems', addStatusId(queuedIds, statusId).take(MAX_QUEUED_ITEMS));
   }));
+
 };
 
 const shouldDelete = (timelineId: string, excludeAccount?: string) => {
@@ -316,47 +328,64 @@ const handleExpandFail = (state: State, timelineId: string) => {
 export default function timelines(state: State = initialState, action: AnyAction) {
   switch (action.type) {
     case STATUS_CREATE_REQUEST:
+      console.log(JSON.stringify(action, null, 2));
       if (action.params.scheduled_at) return state;
       return importPendingStatus(state, action.params, action.idempotencyKey);
     case STATUS_CREATE_SUCCESS:
+      console.log(JSON.stringify(action, null, 2));
       if (action.status.scheduled_at) return state;
       return importStatus(state, action.status, action.idempotencyKey);
     case TIMELINE_EXPAND_REQUEST:
+      console.log(JSON.stringify(action, null, 2));
       return setLoading(state, action.timeline, true);
     case TIMELINE_EXPAND_FAIL:
+      console.log(JSON.stringify(action, null, 2));
       return handleExpandFail(state, action.timeline);
     case TIMELINE_EXPAND_SUCCESS:
-      return expandNormalizedTimeline(state, action.timeline, fromJS(action.statuses) as ImmutableList<ImmutableMap<string, any>>, action.next, action.partial, action.isLoadingRecent);
+      return expandNormalizedTimeline(state, action.timeline, fromJS(action.statuses) as ImmutableList<ImmutableMap<string, any>>, action.next, action.partial, action.isLoadingRecent, action.isLoadingMore);
     case TIMELINE_UPDATE:
+      console.log(JSON.stringify(action, null, 2));
       return updateTimeline(state, action.timeline, action.statusId);
     case TIMELINE_UPDATE_QUEUE:
+      console.log(JSON.stringify(action, null, 2));
       return updateTimelineQueue(state, action.timeline, action.statusId);
     case TIMELINE_DEQUEUE:
+      console.log(JSON.stringify(action, null, 2));
       return timelineDequeue(state, action.timeline);
     case TIMELINE_DELETE:
+      console.log(JSON.stringify(action, null, 2));
       return deleteStatus(state, action.id, action.accountId, action.references, action.reblogOf);
     case TIMELINE_CLEAR:
+      console.log(JSON.stringify(action, null, 2));
       return clearTimeline(state, action.timeline);
     case ACCOUNT_BLOCK_SUCCESS:
     case ACCOUNT_MUTE_SUCCESS:
+      console.log(JSON.stringify(action, null, 2));
       return filterTimelines(state, action.relationship, action.statuses);
     case ACCOUNT_UNFOLLOW_SUCCESS:
+      console.log(JSON.stringify(action, null, 2));
       return filterTimeline(state, 'home', action.relationship, action.statuses);
     case TIMELINE_SCROLL_TOP:
+      console.log(JSON.stringify(action, null, 2));
       return updateTop(state, action.timeline, action.top);
     case TIMELINE_CONNECT:
+      console.log(JSON.stringify(action, null, 2));
       return timelineConnect(state, action.timeline);
     case TIMELINE_DISCONNECT:
+      console.log(JSON.stringify(action, null, 2));
       return timelineDisconnect(state, action.timeline);
     case GROUP_REMOVE_STATUS_SUCCESS:
+      console.log(JSON.stringify(action, null, 2));
       return removeStatusFromGroup(state, action.groupId, action.id);
     case TIMELINE_REPLACE:
+      console.log(JSON.stringify(action, null, 2));
       return state
         .update('home', TimelineRecord(), timeline => timeline.withMutations(timeline => {
           timeline.set('items', ImmutableOrderedSet([]));
         }))
         .update('home', TimelineRecord(), timeline => timeline.set('feedAccountId', action.accountId));
     case TIMELINE_INSERT:
+      console.log(JSON.stringify(action, null, 2));
       return state.update(action.timeline, TimelineRecord(), timeline => timeline.withMutations(timeline => {
         timeline.update('items', oldIds => {
 
@@ -372,6 +401,7 @@ export default function timelines(state: State = initialState, action: AnyAction
         });
       }));
     case TIMELINE_CLEAR_FEED_ACCOUNT_ID:
+      console.log(JSON.stringify(action, null, 2));
       return state.update('home', TimelineRecord(), timeline => timeline.set('feedAccountId', null));
     default:
       return state;


### PR DESCRIPTION
When coming back from a detailed status, the timeline tends to add new statuses on top, causing a unpleasing jump messing with user navigation. 