### PR TITLE
[FIX] Remove soapbox name from de and fr translations

### DIFF
--- a/app/soapbox/locales/de.json
+++ b/app/soapbox/locales/de.json
@@ -1147,7 +1147,7 @@
   "time_remaining.seconds": "{number, plural, one {# Sekunde} other {# Sekunden}} verbleibend",
   "trends.count_by_accounts": "{count} {rawCount, plural, eine {Person} other {Personen}} reden darüber",
   "trends.title": "Trends",
-  "ui.beforeunload": "Dein Entwurf geht verloren, wenn du Soapbox FE verlässt.",
+  "ui.beforeunload": "Dein Entwurf geht verloren, wenn du diese Seite verlässt.",
   "unauthorized_modal.text": "Für diese Aktion musst Du angemeldet sein.",
   "unauthorized_modal.title": "Bei {site_title} registrieren",
   "upload_area.title": "Zum Hochladen hereinziehen",

--- a/app/soapbox/locales/es.json
+++ b/app/soapbox/locales/es.json
@@ -1143,7 +1143,7 @@
   "time_remaining.seconds": "{number, plural, one {# segundo restante} other {# segundos restantes}}",
   "trends.count_by_accounts": "{count} {rawCount, plural, one {persona} other {personas}} hablando",
   "trends.title": "Trends",
-  "ui.beforeunload": "Tu borrador se perderá si sales de Soapbox FE.",
+  "ui.beforeunload": "Tu borrador se perderá si sales de esta página.",
   "unauthorized_modal.text": "You need to be logged in to do that.",
   "unauthorized_modal.title": "Sign up for {site_title}",
   "upload_area.title": "Arrastra y suelta para subir",

--- a/app/soapbox/locales/fr.json
+++ b/app/soapbox/locales/fr.json
@@ -1143,7 +1143,7 @@
   "time_remaining.seconds": "{number, plural, one {# second} other {# seconds}} restantes",
   "trends.count_by_accounts": "{count} {rawCount, plural, one {personne} other {personnes}} discutent",
   "trends.title": "Trends",
-  "ui.beforeunload": "Votre brouillon sera perdu si vous quittez Soapbox FE.",
+  "ui.beforeunload": "Votre projet sera perdu si vous quittez cette page.",
   "unauthorized_modal.text": "You need to be logged in to do that.",
   "unauthorized_modal.title": "Sign up for {site_title}",
   "upload_area.title": "Glissez et déposez pour envoyer",

--- a/app/soapbox/locales/fr.json
+++ b/app/soapbox/locales/fr.json
@@ -1143,7 +1143,7 @@
   "time_remaining.seconds": "{number, plural, one {# second} other {# seconds}} restantes",
   "trends.count_by_accounts": "{count} {rawCount, plural, one {personne} other {personnes}} discutent",
   "trends.title": "Trends",
-  "ui.beforeunload": "Votre projet sera perdu si vous quittez cette page.",
+  "ui.beforeunload": "Votre brouillon sera perdu si vous quittez cette page.",
   "unauthorized_modal.text": "You need to be logged in to do that.",
   "unauthorized_modal.title": "Sign up for {site_title}",
   "upload_area.title": "Glissez et déposez pour envoyer",


### PR DESCRIPTION
This removes the application name from notifications, just like in en.json, and changes the message to a more common text.