### PR TITLE
feat: Add Default post language configuration option

### DIFF
--- a/app/soapbox/actions/compose.ts
+++ b/app/soapbox/actions/compose.ts
@@ -298,6 +298,7 @@ const submitCompose = (routerHistory?: History, force = false) =>
       content_type: state.compose.content_type,
       poll: state.compose.poll,
       scheduled_at: state.compose.schedule,
+      language: state.compose.language,
       to,
     };
 

--- a/app/soapbox/actions/settings.ts
+++ b/app/soapbox/actions/settings.ts
@@ -27,6 +27,7 @@ const messages = defineMessages({
   saveSuccess: { id: 'settings.save.success', defaultMessage: 'Your preferences have been saved!' },
 });
 
+const locale = navigator.language.split(/[-_]/)[0] || 'en';
 const defaultSettings = ImmutableMap({
   onboarded: false,
   skinTone: 1,
@@ -41,8 +42,9 @@ const defaultSettings = ImmutableMap({
   missingDescriptionModal: false,
   defaultPrivacy: 'public',
   defaultContentType: 'text/plain',
+  defaultPostLanguage: locale,
   themeMode: 'system',
-  locale: navigator.language.split(/[-_]/)[0] || 'en',
+  locale,
   showExplanationBox: true,
   explanationBox: true,
   autoloadTimelines: true,

--- a/app/soapbox/features/preferences/index.tsx
+++ b/app/soapbox/features/preferences/index.tsx
@@ -75,6 +75,10 @@ const languages = {
   'zh-TW': '繁體中文（臺灣）',
 };
 
+// This is temporary, need to use full range of ISO languages like here.
+// https://akkoma.dev/AkkomaGang/akkoma-fe/issues/386
+const postLanguages = languages;
+
 const messages = defineMessages({
   heading: { id: 'column.preferences', defaultMessage: 'Preferences' },
   display_media_default: { id: 'preferences.fields.display_media.default', defaultMessage: 'Hide media marked as sensitive' },
@@ -178,6 +182,13 @@ const Preferences = () => {
             />
           </ListItem>
         )}
+        <ListItem label={<FormattedMessage id='preferences.fields.post_language' defaultMessage='Default post language' />}>
+          <SelectDropdown
+            items={postLanguages}
+            defaultValue={settings.get('defaultPostLanguage') as string | undefined}
+            onChange={(event: React.ChangeEvent<HTMLSelectElement>) => onSelectChange(event, ['defaultPostLanguage'])}
+          />
+        </ListItem>
       </List>
 
       <List>
@@ -211,4 +222,4 @@ const Preferences = () => {
   );
 };
 
-export { Preferences as default, languages };
+export { Preferences as default, languages, postLanguages };

--- a/app/soapbox/features/preferences/index.tsx
+++ b/app/soapbox/features/preferences/index.tsx
@@ -76,7 +76,7 @@ const languages = {
 };
 
 // This is temporary, need to use full range of ISO languages like here.
-// https://akkoma.dev/AkkomaGang/akkoma-fe/issues/386
+// https://akkoma.dev/AkkomaGang/akkoma-fe/pulls/387
 const postLanguages = languages;
 
 const messages = defineMessages({

--- a/app/soapbox/reducers/compose.ts
+++ b/app/soapbox/reducers/compose.ts
@@ -83,6 +83,7 @@ export const ReducerRecord = ImmutableRecord({
   default_content_type: 'text/plain',
   default_privacy: 'public' as StatusVisibility,
   default_sensitive: false,
+  default_language: null as string | null,
   focusDate: null as Date | null,
   idempotencyKey: '',
   id: null as string | null,
@@ -95,6 +96,7 @@ export const ReducerRecord = ImmutableRecord({
   mounted: 0,
   poll: null as Poll | null,
   privacy: 'public' as StatusVisibility,
+  language: null as string | null,
   progress: 0,
   quote: null as string | null,
   resetFileKey: null as number | null,
@@ -255,12 +257,15 @@ const importAccount = (state: State, account: APIEntity) => {
 
   const defaultPrivacy = settings.get('defaultPrivacy', 'public');
   const defaultContentType = settings.get('defaultContentType', 'text/plain');
+  const defaultPostLanguage = settings.get('defaultPostLanguage', '');
 
   return state.merge({
     default_privacy: defaultPrivacy,
     privacy: defaultPrivacy,
     default_content_type: defaultContentType,
     content_type: defaultContentType,
+    default_language: defaultPostLanguage,
+    language: defaultPostLanguage,
     tagHistory: ImmutableList(tagHistory.get(account.id)),
   });
 };
@@ -270,10 +275,12 @@ const updateAccount = (state: State, account: APIEntity) => {
 
   const defaultPrivacy = settings.get('defaultPrivacy');
   const defaultContentType = settings.get('defaultContentType');
+  const defaultPostLanguage = settings.get('defaultPostLanguage', '');
 
   return state.withMutations(state => {
     if (defaultPrivacy) state.set('default_privacy', defaultPrivacy);
     if (defaultContentType) state.set('default_content_type', defaultContentType);
+    if (defaultPostLanguage) state.set('default_language', defaultPostLanguage);
   });
 };
 

--- a/app/soapbox/reducers/compose.ts
+++ b/app/soapbox/reducers/compose.ts
@@ -291,6 +291,8 @@ const updateSetting = (state: State, path: string[], value: StatusVisibility | s
       return state.set('default_privacy', value as StatusVisibility).set('privacy', value as StatusVisibility);
     case 'defaultContentType':
       return state.set('default_content_type', value).set('content_type', value);
+    case 'defaultPostLanguage':
+      return state.set('default_language', value).set('language', value);
     default:
       return state;
   }


### PR DESCRIPTION
This PR adds option to specify posting language.

Currently, this is exposed only in settings. Next step is to add component to compose form (probably it's best left for another PR, if someone can suggest what widgets i can use for this).

This is my first time working with React, please review it carefully.

Refs #171