### PR TITLE
fix: set maxHeight for compose textarea

### DIFF
--- a/app/soapbox/components/autosuggest_textarea.tsx
+++ b/app/soapbox/components/autosuggest_textarea.tsx
@@ -246,7 +246,7 @@ class AutosuggestTextarea extends ImmutablePureComponent<IAutosuggesteTextarea> 
   render() {
     const { value, suggestions, disabled, placeholder, onKeyUp, autoFocus, children, condensed, id } = this.props;
     const { suggestionsHidden } = this.state;
-    const style = { direction: 'ltr', minRows: 10 };
+    const style = { direction: 'ltr', minRows: 10, maxHeight: '80vh' };
 
     if (isRtl(value)) {
       style.direction = 'rtl';


### PR DESCRIPTION
Closes: https://github.com/BDX-town/Mangane/issues/350

Before:

![Screenshot_2024-11-22_10-36-58](https://github.com/user-attachments/assets/b9673421-4028-4d92-b0ab-467356cc0052)

After:

![Screenshot_2024-11-22_10-40-54](https://github.com/user-attachments/assets/0714f13d-22d9-4d2d-af57-86c9b15fb065)
