### PR TITLE
Don't capitalize usernames

### DIFF
--- a/app/soapbox/components/sidebar-navigation.tsx
+++ b/app/soapbox/components/sidebar-navigation.tsx
@@ -37,7 +37,7 @@ const SidebarNavigation = () => {
               </Link>
               <div>
                 <ProfileDropdown account={account}>
-                  <div className='block capitalize text-lg font-bold leading-none'>
+                  <div className='block text-lg font-bold leading-none'>
                     { account.username }&nbsp;<IconSwitchVertical className='inline w-[14px] h-[14px] text-gray-700 dark:text-gray-400' />
                   </div>
                 </ProfileDropdown>


### PR DESCRIPTION
Forcing the capitalized display of usernames messes up preferred stylization.

For example, this is what my `ProfileDropdown` looks like right now:
![Screenshot 2024-11-26 at 11 03 52](https://github.com/user-attachments/assets/90d68735-63ec-4bb5-b5c1-fb3c02a9b75c)

I prefer to spell my nickname as "flisk" with a lower-case f, so the way it's displayed here is not correct.

Could this class please be dropped?